### PR TITLE
Fix #4 by removing trailing slashes from all endpoint properties

### DIFF
--- a/LLMLauncher.py
+++ b/LLMLauncher.py
@@ -139,7 +139,11 @@ if len(st.session_state.llms["llm_objects"]) > 0:
                 header_template = Template(llm_configs[llm['llm_model']]["templates"]["header_template"])
                 data_template = Template(llm_configs[llm['llm_model']]["templates"]["data_template"])
                 
+                for id in endpoint_template.get_identifiers():
+                    llms["llm_objects"][llm_key][id] = llms["llm_objects"][llm_key][id].rstrip("/")
+
                 url = endpoint_template.substitute(llms["llm_objects"][llm_key])
+
                 headers_json = header_template.substitute(llms["llm_objects"][llm_key])
                 headers = json.loads(headers_json)
                 

--- a/model_types/azure_openai.toml.example
+++ b/model_types/azure_openai.toml.example
@@ -29,10 +29,12 @@ description = "API Key"
 
 [templates]
 # The endpoint_template is the URL that the API call will be made to
+# When creating the endpoint_template assume no inputs from the user will end with a trailing slash
 endpoint_template = "$endpoint/openai/deployments/$deployment_name/chat/completions?api-version=2024-02-01"
 
 # The data_template is the JSON data that will be sent in the body of the API call
 # To use the system and user prompts from the UI, you can use the $llm_system_prompt and $llm_user_prompt variables
+# Must be a valid JSON string
 data_template = """
 {
     "messages": [
@@ -43,6 +45,7 @@ data_template = """
 """
 
 # The header_template is the headers that will be sent with the API call
+# Must be a valid JSON string
 header_template = """
 {
     "Content-Type": "application/json",


### PR DESCRIPTION
get all identifiers in the endpoint template and removing trailing slashes via rstrip
Provided clarification about this in example toml template